### PR TITLE
Adding Tailwind CSS classes to the `/about` page

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -1,5 +1,5 @@
 <template>
   <div class="about">
-    <h1>This is an about page</h1>
+    <h1 class="text-red-500 text-5xl">This is an about page</h1>
   </div>
 </template>


### PR DESCRIPTION
Hey!

So - I have forked your repo, tried to run it, and... it works out of the box.

I can't get the home route to show, am a bit confused as per why, but this has nothing to do with Tailwind CSS.

If you visit the `/about` page, you'll see the `text-red-500` and `text-5xl` applied 👍

Unless you **really** need to use the `vue-cli-service`, I really recommend you just use `vite`, as per the guide on Tailwind CSS documentation. It's much more straightforward than what you needed to do in the `bin/vite` here.